### PR TITLE
Vanilla webpack

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["es2015", "stage-0", "react"]
+}

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,8 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2016 Ragu Ramaswamy https://github.com/rrag/react-stockcharts
+Copyright (c) 2015-2016 Lucify Ltd.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
+
 # A selectable stacked bar chart React component
+
+##  About 
+
+This is a pre-release of a package belonging to the Lucify platform. It has been published merely to satisfy dependencies of other packages. Any APIs may change without notice.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,32 @@
 
 # A selectable stacked bar chart React component
 
-##  About 
+##  About
 
-This is a pre-release of a package belonging to the Lucify platform. It has been published merely to satisfy dependencies of other packages. Any APIs may change without notice.
+This is a pre-release of a package belonging to the Lucify platform. It has been
+published to satisfy dependencies of other packages. Any APIs may change without
+notice.
+
+## Developing as part of a project
+
+To develop this component in tandem with a parent project using `npm link`,
+first link this project to the parent project:
+
+```shell
+$ cd path_to_this_project
+$ npm link
+$ cd path_to_parent_project
+$ npm link lucify-bar-chart-range-selector
+```
+
+Then link the parent project's React folder to this project:
+
+```shell
+$ cd path_to_parent_project
+$ cd node_modules/react
+$ npm link
+$ cd path_to_this_project
+$ npm link react
+```
+
+This is needed in order to prevent React from being loaded twice.

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,7 @@
+machine:
+  environment:
+    PROJECT: $CIRCLE_PROJECT_REPONAME
+    BRANCH: $CIRCLE_BRANCH
+    COMMIT: $CIRCLE_SHA1
+  node:
+    version: 4.2.6

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react": "~0.13.0"
   },
   "devDependencies": {
+    "autoprefixer": "^6.3.5",
     "babel-core": "^6.7.4",
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.6.0",
@@ -45,6 +46,8 @@
     "babel-preset-stage-0": "^6.5.0",
     "css-loader": "^0.23.1",
     "node-sass": "^3.4.2",
+    "postcss-loader": "^0.8.2",
+    "postcss-reporter": "^1.3.3",
     "sass-loader": "^3.2.0",
     "style-loader": "^0.13.1",
     "webpack": "^1.12.14"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "webpack -d --watch",
     "build": "webpack -p",
     "prepublish": "npm run build",
-    "test": "npm run build"
+    "test": "echo \"No tests specified\" && exit 0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -31,10 +31,8 @@
     "url": "https://github.com/lucified/lucify-bar-chart-range-selector/issues"
   },
   "homepage": "https://github.com/lucified/lucify-bar-chart-range-selector#readme",
-  "dependencies": {
-    "d3": "^3.5.16"
-  },
   "peerDependencies": {
+    "d3": "^3.5.16",
     "react": "~0.13.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "webpack -d --watch",
     "build": "webpack -p",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "prepublish": "npm run build",
+    "test": "echo \"No tests specified\" && exit 0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "webpack -d --watch",
     "build": "webpack -p",
     "prepublish": "npm run build",
-    "test": "echo \"No tests specified\" && exit 0"
+    "test": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/src/js/bar-chart-range-selector.jsx
+++ b/src/js/bar-chart-range-selector.jsx
@@ -6,7 +6,7 @@ import Bar from './bar.jsx';
 import styles from '../scss/bar-chart-range-selector.scss';
 
 
-class BarChartRangeSelector extends React.Component {
+export default class BarChartRangeSelector extends React.Component {
 
   static propTypes = {
     data: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,

--- a/src/js/bar-chart-range-selector.jsx
+++ b/src/js/bar-chart-range-selector.jsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import d3 from 'd3';
-//import Bar from './bar.jsx';
+import Bar from './bar.jsx';
 
 import styles from '../scss/bar-chart-range-selector.scss';
 
@@ -429,67 +429,3 @@ class BarChartRangeSelector extends React.Component {
 BarChartRangeSelector.prototype.displayName = 'BarChartRangeSelector';
 
 export default BarChartRangeSelector;
-
-
-class Bar extends React.Component {
-
-  static propTypes = {
-    y0: React.PropTypes.number.isRequired,
-    y1: React.PropTypes.number.isRequired,
-    width: React.PropTypes.number.isRequired,
-    scale: React.PropTypes.func.isRequired,
-    fill: React.PropTypes.string.isRequired,
-    selected: React.PropTypes.bool
-  }
-
-
-  updateHeight() {
-    const scale = this.props.scale;
-    const topY = scale(this.props.y1);
-    const bottomY = scale(this.props.y0);
-
-    d3.select(this.refs.bar.getDOMNode())
-      .transition().duration(250)
-      .attr('y', topY)
-      .attr('height', bottomY - topY);
-  }
-
-
-  componentDidUpdate(_prevProps, _prevState) {
-    this.updateHeight();
-  }
-
-
-  componentDidMount() {
-    this.updateHeight();
-  }
-
-
-  shouldComponentUpdate(nextProps, _nextState) {
-    return nextProps.y0 !== this.props.y0 ||
-      nextProps.y1 !== this.props.y1 ||
-      nextProps.scale !== this.props.scale ||
-      nextProps.width !== this.props.width ||
-      nextProps.fill !== this.props.fill ||
-      nextProps.selected !== this.props.selected;
-  }
-
-
-  render() {
-    let classes = styles.bar;
-    if (this.props.selected) {
-      classes += ' ' + styles.selected;
-    }
-
-    return (
-      <rect
-        ref='bar'
-        className={classes}
-        width={this.props.width}
-        fill={this.props.fill} />
-    );
-  }
-
-}
-
-Bar.prototype.displayName = 'Bar';

--- a/src/js/bar.jsx
+++ b/src/js/bar.jsx
@@ -54,8 +54,6 @@ class Bar extends React.Component {
       classes += ' ' + styles.selected;
     }
 
-    debugger;
-
     return (
       <rect
         ref='bar'

--- a/src/js/bar.jsx
+++ b/src/js/bar.jsx
@@ -1,10 +1,10 @@
 
 import React from 'react';
 import d3 from 'd3';
-
 import styles from '../scss/bar.scss';
 
-class Bar extends React.Component {
+
+export default class Bar extends React.Component {
 
   static propTypes = {
     y0: React.PropTypes.number.isRequired,
@@ -65,4 +65,6 @@ class Bar extends React.Component {
 
 }
 
+
 Bar.prototype.displayName = 'Bar';
+

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,12 @@ var config = {
     loaders: [
       {
         test: /\.scss$/,
-        loaders: ['style', 'css', 'sass']
+        loaders: [
+          require.resolve('style-loader'),
+          require.resolve('css-loader') + '?modules&importLoaders=2&localIdentName=[name]__[local]___[hash:base64:5]',
+          require.resolve('postcss-loader'),
+          require.resolve('sass-loader')
+        ]
       },
       {
         test: /\.(jsx|js)$/,
@@ -45,7 +50,11 @@ var config = {
   resolveLoader: {
     modulesDirectories: ['node_modules'],
     fallback: path.join(__dirname, 'node_modules')
-  }
+  },
+  postcss: [
+    require('autoprefixer'),
+    require('postcss-reporter')
+  ]
 };
 
 module.exports = config;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,19 +20,31 @@ var config = {
       {
         test: /\.(jsx|js)$/,
         exclude: /node_modules/,
-        loader: 'babel-loader',
-        query: {
-          presets: ['es2015', 'stage-0', 'react']
-        }
+        loader: 'babel-loader'
       }
     ]
   },
   externals: {
-    'react': 'React',
+    react: {
+      root: 'React',
+      commonjs: 'react',
+      commonjs2: 'react',
+      amd: 'react'
+    },
     'd3': 'd3'
   },
   resolve: {
-    extensions: ['', '.js', '.jsx', '.scss']
+    extensions: ['', '.js', '.jsx', '.scss'],
+    root: [path.join(__dirname, 'build')],
+    fallback: [path.join(__dirname, 'node_modules')],
+    alias: {
+      react: path.resolve('./node_modules/react'),
+      'react-dom': path.resolve('./node_modules/react-dom')
+    }
+  },
+  resolveLoader: {
+    modulesDirectories: ['node_modules'],
+    fallback: path.join(__dirname, 'node_modules')
   }
 };
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,7 +54,16 @@ var config = {
   postcss: [
     require('autoprefixer'),
     require('postcss-reporter')
-  ]
+  ],
+  plugins: [
+    function() {
+      this.plugin('done', function(stats) {
+        if (stats.compilation.errors && stats.compilation.errors.length && process.argv.indexOf('--watch') == -1) {
+          console.log(stats.compilation.errors);
+          process.exit(1); // webpack doesn't exit with status code != 0 if there are errors
+        }
+      });
+    }]
 };
 
 module.exports = config;


### PR DESCRIPTION
Use vanilla Webpack to build JS files.

Note that this requires doing the following in order to not have React be included twice:
```shell
cd path_to_project_that_includes_this
cd node_modules/react
npm link
cd path_to_this_project
npm link react
```

I.e. use the including project's React library for this.