### PR TITLE
Fix range off-by-one bug

### DIFF
--- a/src/js/bar-chart-range-selector.jsx
+++ b/src/js/bar-chart-range-selector.jsx
@@ -175,10 +175,6 @@ export default class BarChartRangeSelector extends React.Component {
     const extent = this.brush.extent();
     let roundedExtent;
 
-    // subtract 1 because the end extent is one larger than the actual value
-    // to include the proper bar graphs in d3.brush.extent()
-    extent[1] = extent[1] - 1;
-
     // if dragging, preserve the width of the extent
     if (d3.event.mode === 'move') {
       const diff = Math.round(extent[1] - extent[0]);
@@ -210,7 +206,9 @@ export default class BarChartRangeSelector extends React.Component {
 
   handleRangeChange(range) {
     if (this.props.onChange) {
-      this.props.onChange(range);
+      // subtract 1 because the end extent is one larger than the actual value
+      // to include the proper bar graphs in d3.brush.extent()
+      this.props.onChange([range[0], range[1] - 1]);
     }
   }
 

--- a/src/js/bar-chart-range-selector.jsx
+++ b/src/js/bar-chart-range-selector.jsx
@@ -370,7 +370,7 @@ export default class BarChartRangeSelector extends React.Component {
           </text>
           <text key='range-label-end' textAnchor='middle'
             transform={`translate(${xScale(range[1])},${y})`}>
-            {this.props.rangeFormat(range[1] - 1)}
+            {this.props.rangeFormat(range[1])}
           </text>
         </g>
       );

--- a/src/js/bar-chart-range-selector.jsx
+++ b/src/js/bar-chart-range-selector.jsx
@@ -273,7 +273,7 @@ export default class BarChartRangeSelector extends React.Component {
       // bar chart area, which basically means going to the next boundary, i.e.
       // increase the end range by one. This needs to be converted back to the
       // "actual" range when passing the changes back to the parent component,
-      // which is done in brushed()
+      // which is done in handleRangeChange
       this.props.selectedRange[1] + 1
     ];
   }

--- a/src/js/bar-chart-range-selector.jsx
+++ b/src/js/bar-chart-range-selector.jsx
@@ -175,16 +175,21 @@ export default class BarChartRangeSelector extends React.Component {
     const extent = this.brush.extent();
     let roundedExtent;
 
+    // subtract 1 because the end extent is one larger than the actual value
+    // to include the proper bar graphs in d3.brush.extent()
+    extent[1] = extent[1] - 1;
+
     // if dragging, preserve the width of the extent
     if (d3.event.mode === 'move') {
+      const diff = Math.round(extent[1] - extent[0]);
 
-      const diff = extent[1] - extent[0];
       if (diff == 0) {
         return;
       }
 
       const d1 = Math.round(extent[1]);
       const d0 = Math.round(d1 - diff);
+
       roundedExtent = [d0, d1];
     }
 
@@ -264,7 +269,15 @@ export default class BarChartRangeSelector extends React.Component {
 
 
   getSelectedRange() {
-    return this.props.selectedRange;
+    return [
+      this.props.selectedRange[0],
+      // This is an annoying hack. We need the extent to cover the whole last
+      // bar chart area, which basically means going to the next boundary, i.e.
+      // increase the end range by one. This needs to be converted back to the
+      // "actual" range when passing the changes back to the parent component,
+      // which is done in brushed()
+      this.props.selectedRange[1] + 1
+    ];
   }
 
 
@@ -353,12 +366,14 @@ export default class BarChartRangeSelector extends React.Component {
 
       return (
         <g className={styles['range-labels']}>
-          {range.map((d,i) =>
-            <text key={'range-label-' + i} textAnchor='middle'
-              transform={`translate(${xScale(d)},${y})`}>
-              {this.props.rangeFormat(d)}
-            </text>
-          )}
+          <text key='range-label-start' textAnchor='middle'
+            transform={`translate(${xScale(range[0])},${y})`}>
+            {this.props.rangeFormat(range[0])}
+          </text>
+          <text key='range-label-end' textAnchor='middle'
+            transform={`translate(${xScale(range[1])},${y})`}>
+            {this.props.rangeFormat(range[1] - 1)}
+          </text>
         </g>
       );
     }
@@ -371,6 +386,7 @@ export default class BarChartRangeSelector extends React.Component {
     const yScale = this.getYScale();
     const colors = this.getColors();
     const contentWidth = this.getContentWidth();
+    const selectedRange = this.getSelectedRange();
     let barWidth = contentWidth/data.length;
     let barPadding = 0;
 
@@ -393,8 +409,7 @@ export default class BarChartRangeSelector extends React.Component {
           y1={c.y1}
           scale={yScale}
           fill={colors(c.key)}
-          selected={d.key >= this.getSelectedRange()[0] &&
-                    d.key < this.getSelectedRange()[1]} />
+          selected={d.key >= selectedRange[0] && d.key < selectedRange[1]} />
       );
 
       return (

--- a/src/js/example.jsx
+++ b/src/js/example.jsx
@@ -20,6 +20,7 @@ export default class Example extends React.Component {
     return (
       <div>
         <h3>Example of bar chart range selector</h3>
+        <p>Selected: {this.state.selectedTimeRange[0]} to {this.state.selectedTimeRange[1]}</p>
         <BarChartRangeSelector
           onChange={this.handleTimeRangeChange.bind(this)}
           data={this.getData()}


### PR DESCRIPTION
We use a linear scale for the x axis in the chart. Because of this, the end of the extent was being drawn to the x position of that value, i.e. the left side of the last "selected" bar chart. The end result is that it looked like we were selecting one bar less than was actually the case.

Fix this by internally increasing the end range by one, and subtracting it before we send the range back up to the parent component.